### PR TITLE
Documentation and Bug Fix.

### DIFF
--- a/parse-number.lisp
+++ b/parse-number.lisp
@@ -60,18 +60,18 @@
   "A list of all of the whitespace characters.")
 
 (declaim (inline white-space-p))
-;;; Is the given character a whitespace character?
 (defun white-space-p (x)
+  "Is the given character a whitespace character?"
   (declare (optimize (speed 3) (safety 0))
 	   (type character x))
   (and (find x *white-space-characters*) t))
 
 (declaim (inline parse-integer-and-places))
-;;; Parse an integer and return a 'parsed-integer'. This is an object
-;;; whose numerical value can be accessed with the function
-;;; number-value and whose length can be accessed with the function
-;;; place.
 (defun parse-integer-and-places (string start end &key (radix 10))
+  "Parse an integer and return a 'parsed-integer'. This is an object
+   whose numerical value can be accessed with the function
+   number-value and whose length can be accessed with the function
+   place."
   (declare (optimize (speed 3) (safety 1))
 	   (type string string)
 	   (type fixnum start end radix))
@@ -118,8 +118,8 @@
 								 )))))))
 
 (declaim (inline number-value places))
-(defun number-value (x) (car x))
-(defun places (x) (cdr x))
+(defun number-value (x) "Get the value of a parsed-integer." (car x))
+(defun places (x) "Get the length of a parsed-integer." (cdr x))
 
 ;; Numbers which could've been parsed, but intentionally crippled not to:
 ;; #xFF.AA
@@ -224,7 +224,7 @@
 				     :radix radix)))))
 
 (defun base-for-exponent-marker (char)
-  "Return the base for an exponent-marker"
+  "Return the base for an exponent-marker."
   (case char
     ((#\d #\D)
      10.0d0)

--- a/parse-number.lisp
+++ b/parse-number.lisp
@@ -56,15 +56,21 @@
 
 (declaim (type cons *white-space-characters*))
 (defparameter *white-space-characters*
-  '(#\Space #\Tab #\Return #\Linefeed))
+  '(#\Space #\Tab #\Return #\Linefeed)
+  "A list of all of the whitespace characters.")
 
 (declaim (inline white-space-p))
+;;; Is the given character a whitespace character?
 (defun white-space-p (x)
   (declare (optimize (speed 3) (safety 0))
 	   (type character x))
   (and (find x *white-space-characters*) t))
 
 (declaim (inline parse-integer-and-places))
+;;; Parse an integer and return a 'parsed-integer'. This is an object
+;;; whose numerical value can be accessed with the function
+;;; number-value and whose length can be accessed with the function
+;;; place.
 (defun parse-integer-and-places (string start end &key (radix 10))
   (declare (optimize (speed 3) (safety 1))
 	   (type string string)
@@ -87,6 +93,10 @@
       (cons integer relevant-digits))))
 
 (defun parse-integers (string start end splitting-points &key (radix 10))
+  "Parse a string containing multiple integers where SPLITTING-POINTS
+   is a list of locations where each location is inbetween
+   consecutive integers. This will return a list of parsed-integers.
+   The last parsed-integer will have a negative value for its length."
   (declare (optimize (speed 3) (safety 1))
 	   (type string string)
 	   (type fixnum start end radix))
@@ -214,6 +224,7 @@
 				     :radix radix)))))
 
 (defun base-for-exponent-marker (char)
+  "Return the base for an exponent-marker"
   (case char
     ((#\d #\D)
      10.0d0)
@@ -227,6 +238,9 @@
      10.0l0)))
 
 (defun make-float/frac (radix exp-marker whole-place frac-place exp-place)
+  "Create a float using EXP-MARKER as the exponent-marker and the
+   parsed-integers WHOLE-PLACE, FRAC-PLACE, and EXP-PLACE as the
+   integer part, fractional part, and exponent respectively."
   (let* ((base (base-for-exponent-marker exp-marker))
          (exp (expt base (number-value exp-place))))
     (+ (* exp (number-value whole-place))
@@ -235,6 +249,9 @@
                 (places frac-place))))))
 
 (defun make-float/whole (exp-marker whole-place exp-place)
+  "Create a float where EXP-MARKER is the exponent-marker and the
+   parsed-integers WHOLE-PLACE and EXP-PLACE as the integer part and
+   the exponent respectively."
   (* (number-value whole-place)
      (expt (base-for-exponent-marker exp-marker)
            (number-value exp-place))))
@@ -339,4 +356,3 @@
 				      :start start
 				      :end end
 				      :radix radix))))))))
-

--- a/parse-number.lisp
+++ b/parse-number.lisp
@@ -266,6 +266,15 @@
 	     (error 'invalid-number
 		    :value (subseq string start end)
 		    :reason reason)))
+      (when (position-if #'white-space-p string
+                         :start (position-if-not #'white-space-p string
+                                                 :start start
+                                                 :end end)
+                         :end   (position-if-not #'white-space-p string
+                                                 :start start
+                                                 :end end
+                                                 :from-end t))
+        (invalid-number "Whitespace inside the number."))
       (case first-char
 	((#\-)
 	 (invalid-number "Invalid usage of -"))

--- a/parse-number.lisp
+++ b/parse-number.lisp
@@ -274,7 +274,7 @@
                                                  :start start
                                                  :end end
                                                  :from-end t))
-        (invalid-number "Whitespace inside the number."))
+        (invalid-number "Whitespace inside the number"))
       (case first-char
 	((#\-)
 	 (invalid-number "Invalid usage of -"))
@@ -296,12 +296,18 @@
 			(invalid-number "Multiple .'s in number")
 			(setf .-pos index)))
 		   ((#\e #\E #\f #\F #\s #\S #\l #\L #\d #\D)
-		    (when (= radix 10)
-		      (when exp-pos
-			(invalid-number
-			 "Multiple exponent-markers in number"))
-		      (setf exp-pos index)
-		      (setf exp-marker (char-downcase char)))))
+                    ;; We should only execute this if the base is
+                    ;; not used for the given radix (ie the digit
+                    ;; e is valid in base 15 and up).
+                    (when (>= (+ 10
+                                 (- (char-code (char-upcase char))
+                                    (char-code #\A)))
+                              radix)
+                      (when exp-pos
+                        (invalid-number
+                         "Multiple exponent-markers in number"))
+                      (setf exp-pos index)
+                      (setf exp-marker (char-downcase char)))))
 	      when (eql index (1- end))
 	      do (case char
 		   ((#\/)
@@ -309,7 +315,7 @@
 		   ((#\d #\D #\e #\E #\s #\S #\l #\L #\f #\F)
 		    (when (= radix 10)
 		      (invalid-number "Exponent-marker at end of number")))))
-	(cond ((and /-pos .-pos)
+        (cond ((and /-pos .-pos)
 	       (invalid-number "Both . and / cannot be present simultaneously"))
 	      ((and /-pos exp-pos)
 	       (invalid-number "Both an exponent-marker and / cannot be present simultaneously"))
@@ -324,7 +330,7 @@
                                            :radix radix)
                          (make-float/frac radix exp-marker whole-place frac-place exp-place)))))
 	      (exp-pos
-	       (if (/= radix 10)
+               (if (/= radix 10)
 		   (invalid-number "Only decimals can contain exponent-markers")
 		   (multiple-value-bind (whole-place exp-place)
 		       (parse-integers string start end
@@ -361,7 +367,7 @@
                        (t
                         (invalid-number "Misplaced - sign"))))))
 	      (t
-	       (values (parse-integer string
+               (values (parse-integer string
 				      :start start
 				      :end end
 				      :radix radix))))))))

--- a/tests.lisp
+++ b/tests.lisp
@@ -10,15 +10,26 @@
   '("1" "-1" "1034" "3." "-3." "-364" "80/335" "1.3214" "3.5333" "2.4E4" "6.8d3" "#xFF"
     "#b-1000" "#o-101/75" "13.09s3" "35.66l5" "21.4f2" "#C(1 2)"
     "#c ( #xF #o-1 ) " "#c(1d1 2s1)" "#16rFF" "#9r10" "#C(#9r44/61 4f4)"
-    "2.56 "))
+    "2.56 ")
+  "These are the values that are going to be tested.")
 
-(defparameter *expected-failures* ())
+(defparameter *expected-failures* ()
+  "These are the values that are expected to be parsed incorrectly.")
+
+(defparameter *invalid-values*
+  '("5 . 5" "--10" "/20" "d10" "5/5/5" "1.2.3" "1d0s0" "10/" "10d"
+    "10.5/20" "15/20.5" "5/10d0" "5d05/10" "5d0.1" "#x5.0d0"
+    "#x5l0" "10/-5" "#x5.0" "." "#x10/-5")
+  "These are the values to be tested that when parsed are expected to
+   signal an invalid-number error.")
 
 (defun run-tests ()
+  "Test all of the values and invalid-numbers."
   (format t "~&~16@A (~16@A) = ~16A ~16A~%~%"
 	  "String value" "READ value" "Parsed value" "*rdff*")
   (let ((expected-failures '())
-	(unexpected-failures '()))
+	(unexpected-failures '())
+        (unexpected-non-invalids '()))
     (dolist (value *test-values*)
       (dolist (*read-default-float-format* '(double-float single-float))
 	(let ((left (read-from-string value))
@@ -32,11 +43,22 @@
 	    (if (find value *expected-failures* :test #'string=)
 		(pushnew value expected-failures :test #'string=)
 		(pushnew value unexpected-failures :test #'string=))))))
+    (format t "~2&~16@A: ~26@A~%~%" "String Value" "Invalid")
+    (dolist (value *invalid-values*)
+      (dolist (*read-default-float-format* '(double-float single-float))
+        (let ((invalid (handler-case (progn (parse-number value) nil)
+                         (invalid-number () t))))
+          (format t "~&~18@S ~26@A ~77T~A"
+                  value invalid *read-default-float-format*)
+          (unless invalid
+              (pushnew value unexpected-non-invalids :test #'string=)))))
     (flet ((format-failures (label val)
-	     (when val
-	       (format t "~A: ~{~_~A~^, ~}.~%" label val))))
+             (when val
+               (format t "~A: ~{~_~A~^, ~}.~%" label val))))
       (format-failures "Expected failures" expected-failures)
       (format-failures "Unexpected failures" unexpected-failures)
       (format-failures "Unexpected successes"
-		       (set-difference *expected-failures* expected-failures
-				       :test #'string=)))))
+                       (set-difference *expected-failures* expected-failures
+                                       :test #'string=))
+      (format-failures "Unexpected non-invalid numbers"
+                       unexpected-non-invalids))))


### PR DESCRIPTION
I added some documentation throughout all of the code.

More importantly I noticed a bug where a string with whitespace inside of it would be parsed incorrectly. An example would be the string "5 . 5" which would be parsed as the number 5.5. I added a check to determine if there are any whitespace characters in between non-whitespace characters. 

If compatibility with read is necessary, an alternative solution would have been to set the end of the string being parsed to be the smaller of the end passed in and the position of the first whitespace character after a non-whitespace character. I will leave it to you to decide what to do. 