### PR TITLE
Signal an invalid-number error on whitespace-only strings

### DIFF
--- a/parse-number.lisp
+++ b/parse-number.lisp
@@ -272,9 +272,10 @@
                     :value (subseq string start end)
                     :reason reason)))
       (when (position-if #'white-space-p string
-                         :start (position-if-not #'white-space-p string
-                                                 :start start
-                                                 :end end)
+                         :start (or (position-if-not #'white-space-p string
+                                                     :start start
+                                                     :end end)
+                                    0)
                          :end   (position-if-not #'white-space-p string
                                                  :start start
                                                  :end end

--- a/tests.lisp
+++ b/tests.lisp
@@ -19,7 +19,7 @@
 (defparameter *invalid-values*
   '("5 . 5" "--10" "/20" "d10" "5/5/5" "1.2.3" "1d0s0" "10/" "10d"
     "10.5/20" "15/20.5" "5/10d0" "5d05/10" "5d0.1" "#x5.0d0"
-    "#x5l0" "10/-5" "#x5.0" "." "#x10/-5")
+    "#x5l0" "10/-5" "#x5.0" "." "#x10/-5" " ")
   "These are the values to be tested that when parsed are expected to
    signal an invalid-number error.")
 


### PR DESCRIPTION
Previously NIL could be passed as the :START argument to POSITION-IF,
which resulted in signaling an implementation-specific error.